### PR TITLE
A fix for a problem transforming a top level array of objects; object filtered out by predicate leaves "undefined" as its mark

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -8,11 +8,20 @@ const transform = (json, rules) => {
         return res;
       }
     }
+    // at this point, not yet returned.
+    // the runner function will return "undefined".
   };
 
   const adaptedRunner = ast => {
     if (Array.isArray(ast)) {
-      return ast.map(r => runner(r));
+      let result = ast.map(r => runner(r));
+      // a call to runner(r) may return "undefined".
+      // "undefined" should not appear in the result array.
+      // so let's filter it out.
+      result = result.filter((e) => {
+        return e !== undefined;
+      });
+      return result;
     } else {
       return runner(ast);
     }

--- a/src/transform.js
+++ b/src/transform.js
@@ -19,7 +19,7 @@ const transform = (json, rules) => {
       // "undefined" should not appear in the result array.
       // so let's filter it out.
       result = result.filter((e) => {
-        return e !== undefined;
+        return (e !== undefined && e !== null);
       });
       return result;
     } else {

--- a/test/topLevelArrayCaseSpec.js
+++ b/test/topLevelArrayCaseSpec.js
@@ -1,0 +1,26 @@
+const transformer = require('./../build/json-transforms');
+const identity = transformer.identity;
+const pathRule = transformer.pathRule;
+const transform = transformer.transform;
+
+describe('Case of top level array of automobile objects -', () => {
+  it('find Honda cars out of top level array', () => {
+    const automobiles = [
+      { maker: 'Nissan', model: 'Teana', year: 2011 },
+      { maker: 'Honda', model: 'Jazz', year: 2010 },
+      { maker: 'Honda', model: 'Civic', year: 2007 },
+      { maker: 'Toyota', model: 'Yaris', year: 2008 },
+      { maker: 'Honda', model: 'Accord', year: 2011 }
+    ];
+    const rules = [pathRule('.{.maker === "Honda"}', (d) => d.match)];
+    const transformed = transform(automobiles, rules);
+    expect(transformed).toEqual([
+      { maker: 'Honda', model: 'Jazz', year: 2010 },
+      { maker: 'Honda', model: 'Civic', year: 2007 },
+      { maker: 'Honda', model: 'Accord', year: 2011 }
+    ]);
+
+    console.log('---------- topLevelArrayCaseSepec.js ----------');
+    console.log(transformed);
+  });
+});


### PR DESCRIPTION
I have made an issue#12, please refer

https://github.com/ColinEberhardt/json-transforms/issues/12

for detail
